### PR TITLE
Escape quotes in Repo Description

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -56,7 +56,7 @@ jobs:
           pushd /tmp
           cookiecutter gh:simonw/click-app --no-input \
             app_name=$REPO_NAME \
-            description="$(echo $INFO | jq -r .repository.description)" \
+            description="$(echo $INFO | jq -r .repository.description | sed 's/\"/\\\"/g')" \
             github_username="$(echo $INFO | jq -r .repository.owner.login)" \
             author_name="$(echo $INFO | jq -r .repository.owner.name)"
           popd


### PR DESCRIPTION
Without this logic, quotes in the Description can result in the following invalid `pyproject.toml`:

```
[project]
name = "my-project"
version = "0.1"
description = "Air-quotes are really "cool""
readme = "README.md"
...
```

and invalid `cli.py`:

```
...
@click.group()
@click.version_option()
def cli():
    "Air-quotes are really "cool""
...
```